### PR TITLE
update email address to the direct support email address and change copy

### DIFF
--- a/src/decrypt.html
+++ b/src/decrypt.html
@@ -29,7 +29,7 @@
 
   <div>
     <p>Use this offline tool to decrypt your encrypted Standard Notes backup file(s).</p>
-    <p>Any questions? Send an email to <a href="mailto:hello@standardnotes.org">hello@standardnotes.org</a>.
+    <p>If you have any questions, please send an email to <a href="mailto:help@standardnotes.org">help@standardnotes.org</a>.
   </div>
 
   <div style="margin-top: 30px;">


### PR DESCRIPTION
I know that `hello@standardnotes.org` will redirect to `help@standardnotes.org`, but `help@standardnotes.org` seems more fitting. Feel free to reject this PR, though.