### PR TITLE
Update URL for decrypt script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To further your protections against general disruptions in your network or ours,
 
 ### Decrypting a Backup Offline
 
-[Download the offline decrypt script](https://raw.githubusercontent.com/standardfile/decrypt/master/dist/decrypt.html) and open it with any browser.
+[Download the offline decrypt script](https://raw.githubusercontent.com/standardnotes/decrypt/master/dist/decrypt.html) and open it with any browser.
 
 You can right click the link above and choose "Save link as", or open the page directly and save the page with Cmd/Ctrl + S.
 


### PR DESCRIPTION
This updates the URL for the decrypt script in the readme from pointing to the `standardfiles` organisation to `standardnotes`.

I was initially worried when I saw the readme link to another github organisation but realised you've renamed and the link redirects. However, I think it would be more transparent to link directly to the correct repo.